### PR TITLE
fix(duatic_helpers): handle multiple publishers to /joint_topics

### DIFF
--- a/duatic_helpers/duatic_helpers/duatic_robots_helper.py
+++ b/duatic_helpers/duatic_helpers/duatic_robots_helper.py
@@ -95,7 +95,7 @@ class DuaticRobotsHelper:
 
     def _joint_sate_callback(self, msg):
         """Callback to update joint states and detect robots."""
-        self._joint_states = dict(zip(msg.name, msg.position))
+        self._joint_states.update(dict(zip(msg.name, msg.position)))
 
         if self._robot_count <= 0:
             self._robot = self.get_robots_with_components()


### PR DESCRIPTION
If multiple nodes publish joint_states msgs about seperate joints, this resulted in the helper function throwing errors, as it only checked the most recent message. By updating a dictionary with the messages, instead of saving only the last arriving one, we don't have that problem anymore