### PR TITLE
Added support for c++ nodes, added message package

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,65 @@
+---
+BasedOnStyle:  Google
+AccessModifierOffset: -2
+ConstructorInitializerIndentWidth: 2
+AlignEscapedNewlinesLeft: false
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
+AlwaysBreakTemplateDeclarations: true
+AlwaysBreakBeforeMultilineStrings: false
+BreakBeforeBinaryOperators: false
+BreakBeforeTernaryOperators: false
+BreakConstructorInitializersBeforeComma: true
+BinPackParameters: true
+ColumnLimit:    120
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+DerivePointerBinding: false
+PointerBindsToType: true
+ExperimentalAutoDetectBinPacking: false
+IndentCaseLabels: true
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 60
+PenaltyBreakString: 1
+PenaltyBreakFirstLessLess: 1000
+PenaltyExcessCharacter: 1000
+PenaltyReturnTypeOnItsOwnLine: 90
+SpacesBeforeTrailingComments: 2
+Cpp11BracedListStyle: false
+Standard:        Auto
+IndentWidth:     2
+TabWidth:        2
+UseTab:          Never
+IndentFunctionDeclarationAfterType: false
+SpacesInParentheses: false
+SpacesInAngles:  false
+SpaceInEmptyParentheses: false
+SpacesInCStyleCastParentheses: false
+SpaceAfterControlStatementKeyword: true
+SpaceBeforeAssignmentOperators: true
+ContinuationIndentWidth: 4
+SortIncludes: false
+SpaceAfterCStyleCast: false
+
+# Configure each individual brace in BraceWrapping
+BreakBeforeBraces: Custom
+
+# Control of individual brace wrapping cases
+BraceWrapping:
+    AfterCaseLabel: 'true'
+    AfterClass: 'true'
+    AfterControlStatement: Never
+    AfterEnum : 'true'
+    AfterFunction : 'true'
+    AfterNamespace : 'true'
+    AfterStruct : 'true'
+    AfterUnion : 'true'
+    BeforeCatch : 'false'
+    BeforeElse : 'false'
+    IndentBraces : 'false'
+...

--- a/duatic_helper_msgs/CMakeLists.txt
+++ b/duatic_helper_msgs/CMakeLists.txt
@@ -1,0 +1,19 @@
+cmake_minimum_required(VERSION 3.8)
+project(duatic_helper_msgs)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+# find dependencies
+find_package(ament_cmake REQUIRED)
+find_package(rosidl_default_generators REQUIRED)
+find_package(std_msgs REQUIRED)
+find_package(sensor_msgs REQUIRED)
+
+rosidl_generate_interfaces(${PROJECT_NAME}
+  "srv/GetJointStates.srv"
+  DEPENDENCIES std_msgs sensor_msgs
+)
+
+ament_package()

--- a/duatic_helper_msgs/package.xml
+++ b/duatic_helper_msgs/package.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>duatic_helper_msgs</name>
+  <version>1.0.0</version>
+  <description>Message definition for the the duatic_helpers</description>
+  <maintainer email="lnachtigall@duatic.com">Lennart Nachtigall</maintainer>
+  <author email="lnachtigall@duatic.com">Lennart Nachtigall</author>
+  <license>BSD 3-Clause</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <build_depend>rosidl_default_generators</build_depend>
+  <build_depend>std_msgs</build_depend>
+  <build_depend>sensor_msgs</build_depend>
+  <exec_depend>rosidl_default_runtime</exec_depend>
+
+  <member_of_group>rosidl_interface_packages</member_of_group>
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/duatic_helper_msgs/srv/GetJointStates.srv
+++ b/duatic_helper_msgs/srv/GetJointStates.srv
@@ -1,0 +1,7 @@
+---
+# List of latest received joint states
+sensor_msgs/JointState state
+# List of the timestamps the joint state had when in its header when received + the timestamps when the joint state was received
+# Both lists have the same order as the joints in the state field
+builtin_interfaces/Time[] produce_time_stamps
+builtin_interfaces/Time[] receive_time_stamps

--- a/duatic_helpers/CMakeLists.txt
+++ b/duatic_helpers/CMakeLists.txt
@@ -1,15 +1,13 @@
 cmake_minimum_required(VERSION 3.8)
 
-project(duatic_helpers NONE)
+project(duatic_helpers)
 
-find_package(ament_cmake_core REQUIRED)
+find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_python REQUIRED)
 
 ament_python_install_package(duatic_helpers)
 
-ament_package(
-  CONFIG_EXTRAS "duatic_helpers-extras.cmake"
-)
+
 
 include(cmake/duatic_package.cmake)
 
@@ -32,3 +30,30 @@ if(BUILD_TESTING)
   duatic_add_pytest_test(test_launch_config_as_bool test/test_launch_config_as_bool.py
   )
 endif()
+
+
+
+## And the c++ part
+find_package(rclcpp REQUIRED)
+find_package(duatic_helper_msgs REQUIRED)
+find_package(sensor_msgs REQUIRED)
+
+add_executable(joint_state_provider ./src/joint_state_provider_node.cpp)
+target_compile_features(joint_state_provider PRIVATE c_std_99 cxx_std_20)  # Require C99 and C++20
+target_include_directories(joint_state_provider PRIVATE
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>)
+ament_target_dependencies(joint_state_provider
+  rclcpp
+  duatic_helper_msgs
+  sensor_msgs
+)
+install(TARGETS joint_state_provider
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION lib/${PROJECT_NAME}
+)
+
+ament_package(
+  CONFIG_EXTRAS "duatic_helpers-extras.cmake"
+)

--- a/duatic_helpers/package.xml
+++ b/duatic_helpers/package.xml
@@ -7,14 +7,19 @@
   <maintainer email="mbloechlinger@duatic.com">Marc Blöchlinger</maintainer>
   <license>BSD 3-Clause</license>
 
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
   <depend>launch</depend>
   <depend>launch_ros</depend>
   <depend>osrf_pycommon</depend>
   <depend>rclpy</depend>
   <depend>python3-yaml</depend>
   <depend>python3-types-pyyaml</depend>
+  <depend>rclcpp</depend>
+  <depend>duatic_helper_msgs</depend>
+  <depend>sensor_msgs</depend>
 
-  <buildtool_depend>ament_cmake_core</buildtool_depend>
+
 
   <build_depend>ament_cmake_python</build_depend>
 

--- a/duatic_helpers/src/joint_state_provider_node.cpp
+++ b/duatic_helpers/src/joint_state_provider_node.cpp
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2026 Duatic AG
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+ * following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+ * disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+ * following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <map>
+#include <rclcpp/rclcpp.hpp>
+#include <sensor_msgs/msg/joint_state.hpp>
+#include <duatic_helper_msgs/srv/get_joint_states.hpp>
+
+using GetJointStates = duatic_helper_msgs::srv::GetJointStates;
+
+static std::vector<std::shared_ptr<rclcpp::Subscription<sensor_msgs::msg::JointState>>> joint_state_subscribers_{};
+static std::shared_ptr<rclcpp::Publisher<sensor_msgs::msg::JointState>> joint_state_publisher_{nullptr};
+static std::shared_ptr<rclcpp::Service<GetJointStates>> joint_state_service_{nullptr};
+static std::shared_ptr<rclcpp::TimerBase> update_timer_{nullptr};
+static std::shared_ptr<rclcpp::Node> node_{nullptr};
+
+// Internal representation of the current state of a single joint
+struct JointState
+{
+  std::string name;
+  double position;
+  // These field are also in the official ros2 JointState message definition optional
+  std::optional<double> velocity;
+  std::optional<double> effort;
+  // Producer time - obtained from JointState message header
+  rclcpp::Time produce_time;
+  // Receive time - point of time at which we received this message
+  rclcpp::Time receive_time;
+};
+
+static std::map<std::string, JointState> joint_states_;
+
+static void on_new_joint_state(const sensor_msgs::msg::JointState& msg)
+{
+  // Go through all the fields of the message an create an entry in our joint_states_ map
+  // NOTE as we use a singlethreaded executor there is no need for locking
+  if (msg.position.size() != msg.name.size() || msg.position.size() != msg.velocity.size() ||
+      msg.position.size() != msg.effort.size()) {
+    RCLCPP_ERROR_STREAM_THROTTLE(node_->get_logger(), *node_->get_clock(), 100,
+        "Received invalid joint state message - fields do not have the same size");
+    return;
+  }
+
+  const auto now = node_->now();
+
+  for (std::size_t i = 0; i < msg.name.size(); i++) {
+    JointState state;
+
+    state.name = msg.name[i];
+    state.position = msg.position[i];
+    state.receive_time = now;
+    state.produce_time = msg.header.stamp;
+
+    if (msg.velocity.size() > 0)
+      state.velocity = msg.velocity[i];
+    if (msg.effort.size() > 0)
+      state.effort = msg.effort[i];
+
+    if (joint_states_.count(msg.name[i])) {
+      joint_states_[msg.name[i]] = state;
+    } else {
+      joint_states_.insert({ msg.name[i], state });
+    }
+  }
+}
+static void on_joint_state_request(const GetJointStates::Request::SharedPtr& request [[maybe_unused]],
+                                   GetJointStates::Response::SharedPtr response)
+{
+  // Produce a single joint state message from our internal state and set it in the response
+  // NOTE as we use a singlethreaded executor there is no need for locking
+  sensor_msgs::msg::JointState msg;
+  msg.header.stamp = node_->get_clock()->now();
+
+  for (const auto& elem : joint_states_) {
+    msg.name.push_back(elem.first);
+
+    msg.position.push_back(elem.second.position);
+    if (elem.second.velocity)
+      msg.velocity.push_back(elem.second.velocity.value());
+    if (elem.second.effort)
+      msg.effort.push_back(elem.second.effort.value());
+
+    // Additionally we provide the produce and receive time stamp
+    response->produce_time_stamps.push_back(elem.second.produce_time);
+    response->receive_time_stamps.push_back(elem.second.receive_time);
+  }
+
+  response->state = msg;
+}
+
+// Regular update at which the full current state is republished
+static void on_update()
+{
+  sensor_msgs::msg::JointState msg;
+  msg.header.stamp = node_->get_clock()->now();
+  for (const auto& elem : joint_states_) {
+    msg.name.push_back(elem.first);
+
+    msg.position.push_back(elem.second.position);
+    if (elem.second.velocity)
+      msg.velocity.push_back(elem.second.velocity.value());
+    if (elem.second.effort)
+      msg.effort.push_back(elem.second.effort.value());
+  }
+  // If for some reason the publisher was not created successfully but the update was started -> better check it
+  if (joint_state_publisher_)
+    joint_state_publisher_->publish(msg);
+}
+
+int main(int argc, char** argv)
+{
+  rclcpp::init(argc, argv);
+
+  node_ = std::make_shared<rclcpp::Node>("joint_state_provider_node");
+  // Declare all the parameters with usable defaults
+  node_->declare_parameter<double>("publish_rate", 100.0);
+  node_->declare_parameter<std::vector<std::string>>("listen_topics");
+  node_->declare_parameter<std::string>("publish_topic", "/joint_states");
+
+  // The rate in Hz at which the combined joint state message gets published
+  const auto publish_rate = node_->get_parameter("publish_rate").as_double();
+  // Topics we listen for new joint state messages
+  const auto listen_topic_names = node_->get_parameter("listen_topics").as_string_array();
+  // Name of the topic we publish the joint states to (This is per default /joint_states)
+  const auto publish_topic_name = node_->get_parameter("publish_topic").as_string();
+
+  // Subscribe to all configured listen topics.
+  for (const auto& listen_topic : listen_topic_names) {
+    RCLCPP_INFO_STREAM(node_->get_logger(), "Subscribing to topic: " << listen_topic);
+    joint_state_subscribers_.push_back(
+        node_->create_subscription<sensor_msgs::msg::JointState>(listen_topic, 10, &on_new_joint_state));
+  }
+
+  RCLCPP_INFO_STREAM(node_->get_logger(), "Publishing to topic: " << publish_topic_name);
+  joint_state_publisher_ = node_->create_publisher<sensor_msgs::msg::JointState>(publish_topic_name, 10);
+  // Service for reading the latest joint states state
+  joint_state_service_ = node_->create_service<GetJointStates>("/joint_states/get", &on_joint_state_request);
+  RCLCPP_INFO_STREAM(node_->get_logger(), "Publishing rate: " << publish_rate << "Hz");
+
+  update_timer_ =
+      node_->create_wall_timer(std::chrono::milliseconds(static_cast<int64_t>(1000.0 / publish_rate)), &on_update);
+
+  rclcpp::spin(node_);
+
+  rclcpp::shutdown();
+}


### PR DESCRIPTION
Added joint_state_provider node + c++ infrastructure


I would suggest to use this implementation instead of the joint state merge node added here:
https://github.com/Duatic/duatic_control/pull/7/changes

Reasons:

1. Performance - rclpy is slow, the joint states are published on some topics at around 1khz, with a c++ node you barely see the overhead
2. This repository is more fitting for this node (my opinion)
3. Provides a service for requesting joint states -> really useful from python nodes
4. It does full tracking of the timestamps. This is really useful for debugging 


### Configuration

The node has the following three parameters:

```
  node_->declare_parameter<double>("publish_rate", 100.0);
  node_->declare_parameter<std::vector<std::string>>("listen_topics");
  node_->declare_parameter<std::string>("publish_topic", "/joint_states");
```

__publish_rate__: Rate in Hz at which joint states are republished
__listen_topics__: List of topics that the node listens to (and accumulates into a single internal state)
__publish_topic__: Topic to which the the internal state is published regularly


I tested this implementation manually with the dynaarm_single_example (simple republish to a different topic)