### PR TITLE
fixed message size check

### DIFF
--- a/duatic_helpers/duatic_helpers/duatic_param_helper.py
+++ b/duatic_helpers/duatic_helpers/duatic_param_helper.py
@@ -105,7 +105,7 @@ class DuaticParamHelper:
                 f"URDF parameter '{param_name}' at '{node_name}' is empty"
             )
             return None
-            
+
         except Exception as e:
             self.node.get_logger().warn(f"Failed to get URDF from {node_name}: {e}")
             return None

--- a/duatic_helpers/src/joint_state_provider_node.cpp
+++ b/duatic_helpers/src/joint_state_provider_node.cpp
@@ -53,10 +53,10 @@ static std::map<std::string, JointState> joint_states_;
 
 static void on_new_joint_state(const sensor_msgs::msg::JointState& msg)
 {
-  // Go through all the fields of the message an create an entry in our joint_states_ map
-  // NOTE as we use a singlethreaded executor there is no need for locking
-  if (msg.position.size() != msg.name.size() || msg.position.size() != msg.velocity.size() ||
-      msg.position.size() != msg.effort.size()) {
+  // Check if the message is valid - all fields must have the same size
+  if (msg.position.size() != msg.name.size() ||
+      (!msg.velocity.empty() && msg.velocity.size() != msg.name.size()) ||
+      (!msg.effort.empty() && msg.effort.size() != msg.name.size())) {
     RCLCPP_ERROR_STREAM_THROTTLE(node_->get_logger(), *node_->get_clock(), 100,
         "Received invalid joint state message - fields do not have the same size");
     return;


### PR DESCRIPTION
This pull request improves the validation logic for incoming joint state messages in the `joint_state_provider_node.cpp` file. The main change ensures that the code correctly handles cases where the `velocity` and `effort` fields may be empty, which is allowed by the message specification.

Validation logic improvements:

* Updated the message validation in `on_new_joint_state` to only require `velocity` and `effort` arrays to match the size of the `name` array if they are non-empty, making the node more robust to partial joint state messages.