### PR TITLE
Services for welding Gazebo models together

### DIFF
--- a/duatic_helper_msgs/CMakeLists.txt
+++ b/duatic_helper_msgs/CMakeLists.txt
@@ -13,6 +13,12 @@ find_package(sensor_msgs REQUIRED)
 
 rosidl_generate_interfaces(${PROJECT_NAME}
   "srv/GetJointStates.srv"
+  # Scene manipulation for duatic_gazebo's sim_scene node. Here rather than in
+  # duatic_gazebo so that callers depend on the interfaces alone — the simulated clamp
+  # driver needs AttachModel to have a load welded to it, and an end-effector package
+  # has no business pulling in a whole simulation to get two service definitions.
+  "srv/AttachModel.srv"
+  "srv/DetachModel.srv"
   DEPENDENCIES std_msgs sensor_msgs
 )
 

--- a/duatic_helper_msgs/srv/AttachModel.srv
+++ b/duatic_helper_msgs/srv/AttachModel.srv
@@ -1,0 +1,24 @@
+# Weld one Gazebo model rigidly to a link of another, at their current relative pose.
+#
+# Gazebo has no service for this. Its DetachableJoint system can only be declared in
+# SDF, per pair, and gz-sim 8 has no suppress_initial_attach — so a declared object is
+# welded from the moment the world loads. This service injects the system at call time
+# instead, which is what makes arbitrary pairs possible.
+#
+# The HOLDER is the parent. child_model's pose is resolved through the joint, so
+# getting this round the wrong way makes the holder follow the load instead.
+
+# What gets welded. Must be a non-static model.
+string child_model
+# Who holds it. Empty means the robot named by the node's robot_model parameter.
+# May be static — welding to the floor is how a placed object is kept from creeping.
+string parent_model
+# Which link of the holder. Empty means its first link.
+string parent_link
+# Names this coupling, so one object can be held by different holders over its life
+# and each can be released independently. Free-form; "grasp", "stow" and "pin" are
+# the ones the bag-lifting demo uses.
+string tag
+---
+bool success
+string message

--- a/duatic_helper_msgs/srv/DetachModel.srv
+++ b/duatic_helper_msgs/srv/DetachModel.srv
@@ -1,0 +1,14 @@
+# Release a weld made by AttachModel.
+#
+# The joint itself stays in Gazebo once injected; detaching only breaks it, so a later
+# AttachModel with the same tag re-welds without injecting a second joint.
+
+string child_model
+# Which coupling to release. Empty releases every live coupling of this model, which
+# is what a reset wants.
+string tag
+---
+bool success
+string message
+# The tags that were actually released.
+string[] released


### PR DESCRIPTION
Two service definitions for rigidly attaching one Gazebo model to a link of another,
and releasing it again.

## Why they exist

Gazebo offers no service for this. Its `DetachableJoint` system has to be declared in
SDF, per pair, and gz-sim 8 has no `suppress_initial_attach` — so a declared object is
welded from the moment the world loads and gets dragged along as the robot drives.
`duatic_gazebo`'s `sim_scene` node injects the system at call time instead, which is
what allows arbitrary pairs, and these are the services it offers.

## Why here and not in duatic_gazebo

So that callers depend on the interfaces alone. The simulated clamp driver needs
`AttachModel` to have a load welded to it, and an end-effector package has no business
pulling in a whole simulation package for two service definitions. `duatic_helpers` is
already a dependency almost everywhere.

## The one thing worth reading

The **holder** is the parent and the load is the child. `<child_model>`'s pose is
resolved through the joint, so hosting it the other way round makes the holder follow
the load — in our case, lifting a 0.2 kg bag moved the whole rover.

`tag` names a coupling so one object can be held by different holders over its life —
a clamp, then the chassis, then the floor — and each released independently.

## Note on ordering

`duatic_gazebo` and `duatic_end_effectors` both need this merged before they build.
Small and self-contained on purpose, so it can go in first.
