### PR TITLE
Stop publishing and caching empty joint states

### DIFF
--- a/duatic_helpers/duatic_helpers/duatic_robots_helper.py
+++ b/duatic_helpers/duatic_helpers/duatic_robots_helper.py
@@ -51,7 +51,7 @@ class DuaticRobotsHelper:
         )
 
         self._joint_states_subscription = self.node.create_subscription(
-            JointState, "joint_states", self._joint_sate_callback, 10
+            JointState, "joint_states", self._joint_state_callback, 10
         )
 
         self.hardware_components_client = self.node.create_client(
@@ -98,9 +98,43 @@ class DuaticRobotsHelper:
                 self.robot_structure = "generic"
                 self.node.get_logger().info("Identified robot structure: Generic")
 
-    def _joint_sate_callback(self, msg):
-        """Callback to update joint states and detect robots."""
-        self._joint_states = dict(zip(msg.name, msg.position))
+    def _joint_state_callback(self, msg):
+        """Update the cache from a possibly partial JointState, and detect robots once.
+
+        Contract: merges rather than replaces, ignores messages whose arrays are
+        inconsistent, and never leaves a partially updated cache visible.
+
+        The cache therefore only grows: a publisher that goes away leaves its last values
+        behind. Deliberate, and safe here because robot detection is a one-shot — the
+        callback below rebuilds it only while _robot_count is 0, and every external caller
+        reads that frozen result through get_component_names(). Stale joints cannot
+        produce stale robots. Expiring them would need a per-joint timestamp; going back
+        to replacing the cache would trade visible ghosts for joints that vanish
+        sporadically depending on publisher timing, which is far harder to debug.
+        """
+        if not msg.position:
+            # Legal per sensor_msgs/JointState: a publisher may send only velocity or
+            # effort. Nothing here to merge, and nothing wrong with it either.
+            return
+
+        if len(msg.position) != len(msg.name):
+            self.node.get_logger().warning(
+                f"Ignoring JointState with {len(msg.name)} names and "
+                f"{len(msg.position)} positions: arrays must have equal length",
+                throttle_duration_sec=10.0,
+            )
+            return
+        # Merged, not assigned: /joint_states may have several publishers and they need
+        # not each carry the whole robot, so replacing the cache lets one partial message
+        # hide everyone else's joints.
+        #
+        # Copy and rebind rather than update in place. get_joint_states() hands out this
+        # very dict and callers iterate it from other callbacks — with a
+        # MultiThreadedExecutor that is a mutation under an iterator. A rebind gives every
+        # reader a consistent snapshot; the copy costs nothing at a few dozen joints.
+        merged = dict(self._joint_states)
+        merged.update(zip(msg.name, msg.position))
+        self._joint_states = merged
 
         if self._robot_count <= 0:
             self._robot = self.get_robots_with_components()

--- a/duatic_helpers/src/joint_state_provider_node.cpp
+++ b/duatic_helpers/src/joint_state_provider_node.cpp
@@ -112,6 +112,16 @@ static void on_joint_state_request(const GetJointStates::Request::SharedPtr& req
 // Regular update at which the full current state is republished
 static void on_update()
 {
+  // An empty JointState carries no information, and a consumer that replaces its cache
+  // with the message contents is wiped by every one of them. A silent provider is also
+  // the clearer signal: a stream of nothing looks like a working publisher.
+  if (joint_states_.empty()) {
+    RCLCPP_WARN_THROTTLE(node_->get_logger(), *node_->get_clock(), 10000,
+                         "No joint states received from any producer yet — publishing "
+                         "nothing instead of an empty message.");
+    return;
+  }
+
   sensor_msgs::msg::JointState msg;
   msg.header.stamp = node_->get_clock()->now();
   for (const auto& elem : joint_states_) {


### PR DESCRIPTION
## The provider published nothing, loudly

`joint_state_provider_node`'s publish timer ran unconditionally, so with no producer
feeding it the map stayed empty and it still put an **empty** `JointState` on the topic at
the full rate.

That is not harmless. The conventional way to consume this topic is to replace a cached
dict with the message contents, and such a consumer is wiped by every empty message. A
silent provider is also the clearer signal — a stream of nothing looks like a working
publisher.

## DuaticRobotsHelper was exactly such a consumer

Three changes:

* **Merge, not replace.** `/joint_states` may have several publishers and they need not
  each carry the whole robot, so replacing lets one partial message hide everyone else's
  joints.
* **Copy and rebind, not update in place.** `get_joint_states()` hands out the very dict
  the callback writes to, so a caller iterating it while a message arrives would raise, or
  at best see a half-applied update. No configuration today is actually concurrent — the
  helper's node is always a separate one that nothing adds to an executor — so this is
  about the contract the API offers rather than a race anyone has hit. Rebinding a fresh
  dict costs nothing at this size and makes the reader's snapshot whole by construction.
* **A message with names but no positions is ignored quietly.** That is legal per
  `sensor_msgs/JointState` for a publisher sending only velocity or effort. The warning is
  reserved for arrays that genuinely disagree in length, where `zip` would drop the tail
  and leave those joints on stale values.

## The trade-off, stated rather than hidden

The cache now only grows: a publisher that goes away leaves its last values behind. Safe
here, and the docstring says why — robot detection is a one-shot, rebuilt only while
`_robot_count` is 0, and every external caller reads that frozen result through
`get_component_names()`, so stale joints cannot produce stale robots.

Going back to replacing would trade visible stale joints for joints that vanish
sporadically depending on publisher timing, which is much harder to debug. Expiring them
would need a per-joint timestamp; nothing depends on that.

## Not in scope

`/joint_states/get` is still unusable on the DXTR: the provider listens on
`joint_states_robot`/`joint_states_head`, both with zero publishers there because the
broadcaster publishes straight to `/joint_states`. That is a bringup change.

