### PR TITLE
Say how old the joint state is, and stop publishing it when nobody stands behind it

### DIFF
--- a/duatic_helpers/duatic_helpers/duatic_robots_helper.py
+++ b/duatic_helpers/duatic_helpers/duatic_robots_helper.py
@@ -51,7 +51,7 @@ class DuaticRobotsHelper:
         )
 
         self._joint_states_subscription = self.node.create_subscription(
-            JointState, "joint_states", self._joint_sate_callback, 10
+            JointState, "joint_states", self._joint_state_callback, 10
         )
 
         self.hardware_components_client = self.node.create_client(
@@ -98,9 +98,43 @@ class DuaticRobotsHelper:
                 self.robot_structure = "generic"
                 self.node.get_logger().info("Identified robot structure: Generic")
 
-    def _joint_sate_callback(self, msg):
-        """Callback to update joint states and detect robots."""
-        self._joint_states = dict(zip(msg.name, msg.position))
+    def _joint_state_callback(self, msg):
+        """Update the cache from a possibly partial JointState, and detect robots once.
+
+        Contract: merges rather than replaces, ignores messages whose arrays are
+        inconsistent, and never leaves a partially updated cache visible.
+
+        The cache therefore only grows: a publisher that goes away leaves its last values
+        behind. Deliberate, and safe here because robot detection is a one-shot — the
+        callback below rebuilds it only while _robot_count is 0, and every external caller
+        reads that frozen result through get_component_names(). Stale joints cannot
+        produce stale robots. Expiring them would need a per-joint timestamp; going back
+        to replacing the cache would trade visible ghosts for joints that vanish
+        sporadically depending on publisher timing, which is far harder to debug.
+        """
+        if not msg.position:
+            # Legal per sensor_msgs/JointState: a publisher may send only velocity or
+            # effort. Nothing here to merge, and nothing wrong with it either.
+            return
+
+        if len(msg.position) != len(msg.name):
+            self.node.get_logger().warning(
+                f"Ignoring JointState with {len(msg.name)} names and "
+                f"{len(msg.position)} positions: arrays must have equal length",
+                throttle_duration_sec=10.0,
+            )
+            return
+        # Merged, not assigned: /joint_states may have several publishers and they need
+        # not each carry the whole robot, so replacing the cache lets one partial message
+        # hide everyone else's joints.
+        #
+        # Copy and rebind rather than update in place. get_joint_states() hands out this
+        # very dict and callers iterate it from other callbacks — with a
+        # MultiThreadedExecutor that is a mutation under an iterator. A rebind gives every
+        # reader a consistent snapshot; the copy costs nothing at a few dozen joints.
+        merged = dict(self._joint_states)
+        merged.update(zip(msg.name, msg.position))
+        self._joint_states = merged
 
         if self._robot_count <= 0:
             self._robot = self.get_robots_with_components()

--- a/duatic_helpers/src/joint_state_provider_node.cpp
+++ b/duatic_helpers/src/joint_state_provider_node.cpp
@@ -112,6 +112,16 @@ static void on_joint_state_request(const GetJointStates::Request::SharedPtr& req
 // Regular update at which the full current state is republished
 static void on_update()
 {
+  // An empty JointState carries no information, and a consumer that replaces its cache
+  // with the message contents is wiped by every one of them. A silent provider is also
+  // the clearer signal: a stream of nothing looks like a working publisher.
+  if (joint_states_.empty()) {
+    RCLCPP_WARN_THROTTLE(node_->get_logger(), *node_->get_clock(), 10000,
+                         "No joint states received from any producer yet — publishing "
+                         "nothing instead of an empty message.");
+    return;
+  }
+
   sensor_msgs::msg::JointState msg;
   msg.header.stamp = node_->get_clock()->now();
   for (const auto& elem : joint_states_) {

--- a/duatic_helpers/src/joint_state_provider_node.cpp
+++ b/duatic_helpers/src/joint_state_provider_node.cpp
@@ -22,7 +22,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <algorithm>
 #include <map>
+#include <optional>
+#include <set>
 #include <rclcpp/rclcpp.hpp>
 #include <sensor_msgs/msg/joint_state.hpp>
 #include <duatic_helper_msgs/srv/get_joint_states.hpp>
@@ -50,6 +53,12 @@ struct JointState
 };
 
 static std::map<std::string, JointState> joint_states_;
+
+// Joints whose last update is older than this are left out of the published state. Zero disables the check.
+static double stale_timeout_{ 5.0 };
+// Which joints are currently withheld, so both edges can be logged once rather than every cycle. A joint that
+// disappears and returns is worth seeing: it is harder to debug than one that is simply gone.
+static std::set<std::string> stale_joints_;
 
 static void on_new_joint_state(const sensor_msgs::msg::JointState& msg)
 {
@@ -89,6 +98,10 @@ static void on_joint_state_request(const GetJointStates::Request::SharedPtr& req
 {
   // Produce a single joint state message from our internal state and set it in the response
   // NOTE as we use a singlethreaded executor there is no need for locking
+  //
+  // Unlike the published topic this deliberately applies no stale_timeout and keeps the current stamp: every joint
+  // is returned with its own produce and receive time below, so the caller can judge freshness per joint and apply
+  // whatever policy it needs. Filtering here would take that information away without offering a replacement.
   sensor_msgs::msg::JointState msg;
   msg.header.stamp = node_->get_clock()->now();
 
@@ -122,17 +135,62 @@ static void on_update()
     return;
   }
 
+  const auto now = node_->now();
+
   sensor_msgs::msg::JointState msg;
-  msg.header.stamp = node_->get_clock()->now();
+  // Oldest producer stamp among the joints we are about to publish. Restamping with now() instead would claim the
+  // whole message is as fresh as this cycle, which stops being true the moment one producer falls behind: its last
+  // values keep going out at the full rate under a brand new stamp, and a dead arm becomes indistinguishable from a
+  // still one.
+  std::optional<rclcpp::Time> oldest_produce_time;
+
   for (const auto& elem : joint_states_) {
+    const auto& state = elem.second;
+
+    // Measured against receive_time, not produce_time: the question here is whether the producer is still there, and
+    // receive_time is always our own clock. produce_time comes out of a foreign header and is unusable when that
+    // producer runs an unsynchronised clock or does not stamp at all.
+    if (stale_timeout_ > 0.0 && (now - state.receive_time).seconds() > stale_timeout_) {
+      if (stale_joints_.insert(elem.first).second) {
+        RCLCPP_WARN_STREAM(node_->get_logger(), "Joint '" << elem.first << "' had no update for " << stale_timeout_
+                                                          << "s — dropping it from the published state until its "
+                                                             "producer comes back.");
+      }
+      continue;
+    }
+    if (stale_joints_.erase(elem.first) > 0) {
+      RCLCPP_INFO_STREAM(node_->get_logger(), "Joint '" << elem.first << "' is being published again.");
+    }
+
     msg.name.push_back(elem.first);
 
-    msg.position.push_back(elem.second.position);
-    if (elem.second.velocity)
-      msg.velocity.push_back(elem.second.velocity.value());
-    if (elem.second.effort)
-      msg.effort.push_back(elem.second.effort.value());
+    msg.position.push_back(state.position);
+    if (state.velocity)
+      msg.velocity.push_back(state.velocity.value());
+    if (state.effort)
+      msg.effort.push_back(state.effort.value());
+
+    // A producer that leaves its header unstamped only tells us when we received it, which is the closest honest
+    // answer available.
+    const auto produced = state.produce_time.nanoseconds() > 0 ? state.produce_time : state.receive_time;
+    if (!oldest_produce_time || produced < oldest_produce_time.value())
+      oldest_produce_time = produced;
   }
+
+  if (msg.name.empty()) {
+    RCLCPP_WARN_THROTTLE(node_->get_logger(), *node_->get_clock(), 10000,
+                         "Every known joint is stale — publishing nothing instead of a state that no producer stands "
+                         "behind any more.");
+    return;
+  }
+
+  // Never claim to be fresher than the oldest producer, and never older than what we are still willing to keep. The
+  // lower bound matters because a producer stamping from an unsynchronised clock would otherwise put an arbitrarily
+  // old stamp on the whole aggregate, and everything downstream of robot_state_publisher hangs off this single stamp.
+  const auto oldest_acceptable = now - rclcpp::Duration::from_seconds(stale_timeout_);
+  msg.header.stamp = stale_timeout_ > 0.0 ? std::max(oldest_produce_time.value(), oldest_acceptable) :
+                                            oldest_produce_time.value();
+
   // If for some reason the publisher was not created successfully but the update was started -> better check it
   if (joint_state_publisher_)
     joint_state_publisher_->publish(msg);
@@ -147,6 +205,7 @@ int main(int argc, char** argv)
   node_->declare_parameter<double>("publish_rate", 100.0);
   node_->declare_parameter<std::vector<std::string>>("listen_topics");
   node_->declare_parameter<std::string>("publish_topic", "/joint_states");
+  node_->declare_parameter<double>("stale_timeout", 5.0);
 
   // The rate in Hz at which the combined joint state message gets published
   const auto publish_rate = node_->get_parameter("publish_rate").as_double();
@@ -154,6 +213,10 @@ int main(int argc, char** argv)
   const auto listen_topic_names = node_->get_parameter("listen_topics").as_string_array();
   // Name of the topic we publish the joint states to (This is per default /joint_states)
   const auto publish_topic_name = node_->get_parameter("publish_topic").as_string();
+  // How long a joint may go without an update before we stop publishing it. Generous on purpose: it is a backstop
+  // against a producer that has gone away, not the freshness signal itself - that one is the header stamp, which is
+  // exact from the first millisecond. Set to 0 to keep publishing every joint we have ever seen.
+  stale_timeout_ = node_->get_parameter("stale_timeout").as_double();
 
   // Subscribe to all configured listen topics.
   for (const auto& listen_topic : listen_topic_names) {
@@ -167,6 +230,12 @@ int main(int argc, char** argv)
   // Service for reading the latest joint states state
   joint_state_service_ = node_->create_service<GetJointStates>("/joint_states/get", &on_joint_state_request);
   RCLCPP_INFO_STREAM(node_->get_logger(), "Publishing rate: " << publish_rate << "Hz");
+  if (stale_timeout_ > 0.0) {
+    RCLCPP_INFO_STREAM(node_->get_logger(), "Dropping joints not updated for: " << stale_timeout_ << "s");
+  } else {
+    RCLCPP_WARN_STREAM(node_->get_logger(), "Stale joint detection is disabled - joints will be published "
+                                            "indefinitely after their producer goes away");
+  }
 
   update_timer_ =
       node_->create_wall_timer(std::chrono::milliseconds(static_cast<int64_t>(1000.0 / publish_rate)), &on_update);

--- a/duatic_helpers/src/joint_state_provider_node.cpp
+++ b/duatic_helpers/src/joint_state_provider_node.cpp
@@ -56,8 +56,7 @@ static std::map<std::string, JointState> joint_states_;
 
 // Joints whose last update is older than this are left out of the published state. Zero disables the check.
 static double stale_timeout_{ 5.0 };
-// Which joints are currently withheld, so both edges can be logged once rather than every cycle. A joint that
-// disappears and returns is worth seeing: it is harder to debug than one that is simply gone.
+// Currently withheld joints, so both edges are logged once rather than every cycle.
 static std::set<std::string> stale_joints_;
 
 static void on_new_joint_state(const sensor_msgs::msg::JointState& msg)
@@ -99,9 +98,8 @@ static void on_joint_state_request(const GetJointStates::Request::SharedPtr& req
   // Produce a single joint state message from our internal state and set it in the response
   // NOTE as we use a singlethreaded executor there is no need for locking
   //
-  // Unlike the published topic this deliberately applies no stale_timeout and keeps the current stamp: every joint
-  // is returned with its own produce and receive time below, so the caller can judge freshness per joint and apply
-  // whatever policy it needs. Filtering here would take that information away without offering a replacement.
+  // No stale_timeout here, unlike the published topic: every joint comes back with its own produce and receive time
+  // below, so the caller can apply its own policy. Filtering would remove that choice without replacing it.
   sensor_msgs::msg::JointState msg;
   msg.header.stamp = node_->get_clock()->now();
 
@@ -138,18 +136,15 @@ static void on_update()
   const auto now = node_->now();
 
   sensor_msgs::msg::JointState msg;
-  // Oldest producer stamp among the joints we are about to publish. Restamping with now() instead would claim the
-  // whole message is as fresh as this cycle, which stops being true the moment one producer falls behind: its last
-  // values keep going out at the full rate under a brand new stamp, and a dead arm becomes indistinguishable from a
-  // still one.
+  // Oldest producer stamp among the joints we publish. Restamping with now() would call the whole message as fresh as
+  // this cycle, which makes a producer that fell behind indistinguishable from one that has nothing to report.
   std::optional<rclcpp::Time> oldest_produce_time;
 
   for (const auto& elem : joint_states_) {
     const auto& state = elem.second;
 
-    // Measured against receive_time, not produce_time: the question here is whether the producer is still there, and
-    // receive_time is always our own clock. produce_time comes out of a foreign header and is unusable when that
-    // producer runs an unsynchronised clock or does not stamp at all.
+    // Against receive_time, not produce_time: the question is whether the producer is still there, and only our own
+    // clock can answer it. A foreign header is unusable when that producer is unsynchronised or does not stamp.
     if (stale_timeout_ > 0.0 && (now - state.receive_time).seconds() > stale_timeout_) {
       if (stale_joints_.insert(elem.first).second) {
         RCLCPP_WARN_STREAM(node_->get_logger(), "Joint '" << elem.first << "' had no update for " << stale_timeout_
@@ -170,8 +165,7 @@ static void on_update()
     if (state.effort)
       msg.effort.push_back(state.effort.value());
 
-    // A producer that leaves its header unstamped only tells us when we received it, which is the closest honest
-    // answer available.
+    // An unstamped header leaves us the receive time as the closest honest answer.
     const auto produced = state.produce_time.nanoseconds() > 0 ? state.produce_time : state.receive_time;
     if (!oldest_produce_time || produced < oldest_produce_time.value())
       oldest_produce_time = produced;
@@ -184,9 +178,8 @@ static void on_update()
     return;
   }
 
-  // Never claim to be fresher than the oldest producer, and never older than what we are still willing to keep. The
-  // lower bound matters because a producer stamping from an unsynchronised clock would otherwise put an arbitrarily
-  // old stamp on the whole aggregate, and everything downstream of robot_state_publisher hangs off this single stamp.
+  // Never fresher than the oldest producer, never older than stale_timeout. The lower bound keeps an unsynchronised
+  // producer from ageing the whole aggregate without limit — the TF tree hangs off this single stamp.
   const auto oldest_acceptable = now - rclcpp::Duration::from_seconds(stale_timeout_);
   msg.header.stamp = stale_timeout_ > 0.0 ? std::max(oldest_produce_time.value(), oldest_acceptable) :
                                             oldest_produce_time.value();
@@ -213,9 +206,8 @@ int main(int argc, char** argv)
   const auto listen_topic_names = node_->get_parameter("listen_topics").as_string_array();
   // Name of the topic we publish the joint states to (This is per default /joint_states)
   const auto publish_topic_name = node_->get_parameter("publish_topic").as_string();
-  // How long a joint may go without an update before we stop publishing it. Generous on purpose: it is a backstop
-  // against a producer that has gone away, not the freshness signal itself - that one is the header stamp, which is
-  // exact from the first millisecond. Set to 0 to keep publishing every joint we have ever seen.
+  // Generous on purpose: a backstop against a producer that is gone, not the freshness signal - that one is the
+  // header stamp. 0 keeps publishing every joint ever seen.
   stale_timeout_ = node_->get_parameter("stale_timeout").as_double();
 
   // Subscribe to all configured listen topics.


### PR DESCRIPTION
`on_update()` restamped the aggregate with `now()` every cycle. The provider merges joints
from several producers and keeps them indefinitely, so a producer that goes away has its
last values published at 100 Hz under a brand new stamp — a dead arm looks exactly like a
still arm.

## Two changes that only work as a pair

**The header carries the oldest `produce_time`** among the joints in the message, falling
back to `receive_time` for producers that leave the header unstamped. Consumers can ask how
old the state is, at millisecond resolution.

**`stale_timeout` (default 5s) drops a joint entirely** once its producer has been silent
that long, so its disappearance is visible rather than silent. Measured against
`receive_time`, never `produce_time`: the question is whether the producer is still there,
and only our own clock can answer it. `0` restores the old behaviour, with a warning at
startup.

Alone, neither is much use — without the timeout one hung producer ages the aggregate
without bound; without the stamp the timeout is a five-second cliff with no signal before it.

## What this does to TF

`robot_state_publisher` takes this stamp for the whole TF tree, so an old stamp makes *all*
frames old, not just the silent joint's. That is the honest answer, but it means the stamp
needs a floor at `now - stale_timeout`, otherwise a producer with a badly set clock takes TF
down with it.

**This is the part to test on hardware before merging.**

## Why 5s

It is a backstop against a producer that is gone, not the freshness signal — that is the
header stamp. The configured `listen_topics` (`joint_states_robot`, `joint_states_head`) are
fed by `joint_state_broadcaster` at controller-manager rate, so nothing legitimate comes
near it. A tighter value risks joints flickering in and out on a single dropped message.

## Left alone

`/joint_states/get` applies no timeout and keeps its current stamp. It returns
`produce_time_stamps` and `receive_time_stamps` per joint, so the caller can apply its own
policy; filtering would remove that choice without replacing it.

## Testing

Syntax-checked with `-Wall -Wextra` against Jazzy. **Not yet run on hardware or in sim.**

Needs #40 first — this branches off `fix/joint-state-cache` and will retarget `main` when
that merges.